### PR TITLE
chore: update git links for npm to display correct urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/mysticatea/cpx.git"
+    "url": "https://github.com/Akryum/cpx.git"
   },
   "keywords": [
     "cp",
@@ -75,9 +75,9 @@
   "author": "Toru Nagashima",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/mysticatea/cpx/issues"
+    "url": "https://github.com/Akryum/cpx/issues"
   },
-  "homepage": "https://github.com/mysticatea/cpx",
+  "homepage": "https://github.com/Akryum/cpx",
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
When trying to search for the original code with this version, it's redirecting to the fork source instead of this fork. That's a bit confusing.